### PR TITLE
fix: CSP allow Swagger UI (jsdelivr)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ DEBUG=true
 
 # ── Database ─────────────────────────────────────────────────
 POSTGRES_PASSWORD=nexusai_secret
-DATABASE_URL=postgresql+asyncpg://nexusai:nexusai_secret@localhost:5432/nexusai
+DATABASE_URL=postgresql+asyncpg://USER:PASSWORD@127.0.0.1:5433/DATABASE_NAME
 
 # ── Redis ────────────────────────────────────────────────────
 REDIS_PASSWORD=redis_secret
@@ -41,7 +41,7 @@ NVIDIA_DEFAULT_MODEL=openai/gpt-oss-120b
 # OLLAMA_BASE_URL=http://localhost:11434
 
 # ── Auth ─────────────────────────────────────────────────────
-JWT_SECRET=change-me-to-another-random-secret
+JWT_SECRET=change-me-to-another-random-secret-let-it-be
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=10080
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv/
 .ruff_cache/
 coverage.xml
 htmlcov/
+.venv11

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -6,8 +6,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
         response.headers["Content-Security-Policy"] = (
-            "default-src 'self'; script-src 'self' 'unsafe-inline'; "
-            "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:;"
+            "default-src 'self'; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; "
+            "img-src 'self' data: https:; "
+            "font-src 'self' data: cdn.jsdelivr.net;"
         )
         response.headers["Strict-Transport-Security"] = (
             "max-age=31536000; includeSubDomains"


### PR DESCRIPTION
fix(security): allow Swagger UI assets in CSP

Relax Content-Security-Policy script-src, style-src, and font-src to
include cdn.jsdelivr.net so /docs loads Swagger UI. Keeps default-src
'self' and does not whitelist arbitrary third-party origins.