### PR TITLE
fix: add monitor and settings pages

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/src/app/monitor/page.tsx
+++ b/frontend/src/app/monitor/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Activity, AlertCircle, CheckCircle2, Clock, Database, Server, Wifi } from "lucide-react";
+import { Sidebar } from "@/components/dashboard/Sidebar";
+import { api } from "@/lib/api";
+import { Skeleton, useMinimumLoading } from "@/components/ui/Skeleton";
+
+type MetricSummary = {
+  requestCount: string;
+  averageLatency: string;
+  activeRequests: string;
+};
+
+function parseMetricValue(metrics: string, name: string) {
+  const line = metrics
+    .split("\n")
+    .find((entry) => entry.startsWith(name) && !entry.startsWith("#"));
+  const value = Number(line?.trim().split(/\s+/).pop());
+  return Number.isFinite(value) ? value : 0;
+}
+
+function summarizeMetrics(metrics?: string): MetricSummary {
+  if (!metrics) {
+    return { requestCount: "0", averageLatency: "0 ms", activeRequests: "0" };
+  }
+
+  const requestCount =
+    parseMetricValue(metrics, "http_requests_total") ||
+    parseMetricValue(metrics, "http_request_duration_seconds_count");
+  const latencySum = parseMetricValue(metrics, "http_request_duration_seconds_sum");
+  const latencyCount = parseMetricValue(metrics, "http_request_duration_seconds_count");
+  const activeRequests = parseMetricValue(metrics, "http_requests_inprogress");
+  const averageLatency = latencyCount > 0 ? `${Math.round((latencySum / latencyCount) * 1000)} ms` : "0 ms";
+
+  return {
+    requestCount: requestCount.toLocaleString(),
+    averageLatency,
+    activeRequests: activeRequests.toLocaleString(),
+  };
+}
+
+function StatusPill({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium ${
+        ok ? "bg-green-950 text-green-300" : "bg-red-950 text-red-300"
+      }`}
+    >
+      {ok ? <CheckCircle2 size={12} /> : <AlertCircle size={12} />}
+      {label}
+    </span>
+  );
+}
+
+function MetricCard({ icon: Icon, label, value, tone }: any) {
+  return (
+    <div className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-sm text-gray-400">{label}</span>
+        <div className={`flex h-9 w-9 items-center justify-center rounded-lg ${tone}`}>
+          <Icon size={18} className="text-white" />
+        </div>
+      </div>
+      <p className="text-2xl font-bold text-white">{value}</p>
+    </div>
+  );
+}
+
+function MetricCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-9 w-9 rounded-lg" />
+      </div>
+      <Skeleton className="h-8 w-20" />
+    </div>
+  );
+}
+
+export default function MonitorPage() {
+  const healthQuery = useQuery({
+    queryKey: ["monitor", "health"],
+    queryFn: () => api.get("/health").then((response) => response.data),
+    refetchInterval: 30_000,
+  });
+  const readyQuery = useQuery({
+    queryKey: ["monitor", "ready"],
+    queryFn: () => api.get("/health/ready").then((response) => response.data),
+    refetchInterval: 30_000,
+  });
+  const metricsQuery = useQuery({
+    queryKey: ["monitor", "metrics"],
+    queryFn: () => api.get("/metrics", { responseType: "text" }).then((response) => response.data as string),
+    refetchInterval: 30_000,
+  });
+
+  const loading = useMinimumLoading(healthQuery.isLoading || readyQuery.isLoading || metricsQuery.isLoading);
+  const summary = useMemo(() => summarizeMetrics(metricsQuery.data), [metricsQuery.data]);
+  const apiOnline = healthQuery.data?.status === "ok";
+  const dependenciesReady = readyQuery.data?.status === "ready" || readyQuery.data?.ok === true;
+  const hasError = healthQuery.isError || readyQuery.isError || metricsQuery.isError;
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-gray-950">
+      <Sidebar />
+      <main className="flex-1 overflow-auto p-8">
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Monitor</h1>
+            <p className="mt-1 text-sm text-gray-400">API health, dependencies, and runtime metrics</p>
+          </div>
+          <div className="flex flex-wrap justify-end gap-2">
+            <StatusPill ok={apiOnline} label={apiOnline ? "API online" : "API offline"} />
+            <StatusPill ok={dependenciesReady} label={dependenciesReady ? "Ready" : "Not ready"} />
+          </div>
+        </div>
+
+        {hasError && (
+          <div className="mb-5 rounded-xl border border-red-900/60 bg-red-950/30 p-4 text-sm text-red-300">
+            Some monitor data failed to load. Confirm the backend is running and reachable.
+          </div>
+        )}
+
+        <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {loading ? (
+            [0, 1, 2, 3].map((item) => <MetricCardSkeleton key={item} />)
+          ) : (
+            <>
+              <MetricCard icon={Server} label="API Status" value={apiOnline ? "Online" : "Offline"} tone="bg-green-600" />
+              <MetricCard icon={Database} label="Dependencies" value={dependenciesReady ? "Ready" : "Check"} tone="bg-blue-600" />
+              <MetricCard icon={Activity} label="Requests" value={summary.requestCount} tone="bg-indigo-600" />
+              <MetricCard icon={Clock} label="Avg Latency" value={summary.averageLatency} tone="bg-amber-600" />
+            </>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
+          <section className="rounded-xl border border-gray-800 bg-gray-900 p-5 xl:col-span-2">
+            <div className="mb-4 flex items-center gap-2">
+              <Wifi size={16} className="text-indigo-400" />
+              <h2 className="text-sm font-semibold text-gray-300">Service Checks</h2>
+            </div>
+            <div className="space-y-3">
+              {[
+                { label: "Health endpoint", value: healthQuery.data?.status ?? "unavailable", ok: apiOnline },
+                { label: "Readiness endpoint", value: readyQuery.data?.status ?? "unavailable", ok: dependenciesReady },
+                { label: "Metrics endpoint", value: metricsQuery.data ? "collecting" : "unavailable", ok: Boolean(metricsQuery.data) },
+              ].map((check) => (
+                <div key={check.label} className="flex items-center justify-between rounded-lg bg-gray-800 px-4 py-3">
+                  <div>
+                    <p className="text-sm font-medium text-white">{check.label}</p>
+                    <p className="mt-0.5 text-xs text-gray-500">{check.value}</p>
+                  </div>
+                  <StatusPill ok={check.ok} label={check.ok ? "OK" : "Issue"} />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+            <div className="mb-4 flex items-center gap-2">
+              <Activity size={16} className="text-amber-400" />
+              <h2 className="text-sm font-semibold text-gray-300">Traffic</h2>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <p className="text-xs text-gray-500">Active requests</p>
+                <p className="mt-1 text-xl font-semibold text-white">{summary.activeRequests}</p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Refresh interval</p>
+                <p className="mt-1 text-xl font-semibold text-white">30s</p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Metrics source</p>
+                <p className="mt-1 text-sm text-gray-300">Prometheus `/metrics`</p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, KeyRound, Link2, Save, Server, Settings as SettingsIcon, Zap } from "lucide-react";
+import toast from "react-hot-toast";
+import { Sidebar } from "@/components/dashboard/Sidebar";
+import { api } from "@/lib/api";
+import { Skeleton, useMinimumLoading } from "@/components/ui/Skeleton";
+
+const defaultApiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+function ProviderSkeleton() {
+  return (
+    <div className="flex items-center justify-between rounded-lg bg-gray-800 px-4 py-3">
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-5 w-20 rounded-full" />
+    </div>
+  );
+}
+
+export default function SettingsPage() {
+  const [apiUrl, setApiUrl] = useState(defaultApiUrl);
+  const [token, setToken] = useState("");
+
+  useEffect(() => {
+    setApiUrl(localStorage.getItem("nexusai_api_url") || defaultApiUrl);
+    setToken(localStorage.getItem("nexusai_token") || "");
+  }, []);
+
+  const providersQuery = useQuery({
+    queryKey: ["settings", "providers"],
+    queryFn: () => api.get("/api/v1/llm/providers").then((response) => response.data),
+  });
+  const healthQuery = useQuery({
+    queryKey: ["settings", "health"],
+    queryFn: () => api.get("/health").then((response) => response.data),
+  });
+  const providers = providersQuery.data?.providers ?? [];
+  const providersLoading = useMinimumLoading(providersQuery.isLoading);
+
+  const saveConnection = () => {
+    localStorage.setItem("nexusai_api_url", apiUrl.trim() || defaultApiUrl);
+    if (token.trim()) {
+      localStorage.setItem("nexusai_token", token.trim());
+    } else {
+      localStorage.removeItem("nexusai_token");
+    }
+    toast.success("Settings saved");
+  };
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-gray-950">
+      <Sidebar />
+      <main className="flex-1 overflow-auto p-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-white">Settings</h1>
+          <p className="mt-1 text-sm text-gray-400">Connection, provider, and runtime preferences</p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
+          <section className="rounded-xl border border-gray-800 bg-gray-900 p-5 xl:col-span-2">
+            <div className="mb-4 flex items-center gap-2">
+              <Link2 size={16} className="text-indigo-400" />
+              <h2 className="text-sm font-semibold text-gray-300">API Connection</h2>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1 block text-xs text-gray-400">Backend URL</label>
+                <input
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none"
+                  value={apiUrl}
+                  onChange={(event) => setApiUrl(event.target.value)}
+                  placeholder="http://localhost:8000"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-gray-400">Access token</label>
+                <input
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none"
+                  value={token}
+                  onChange={(event) => setToken(event.target.value)}
+                  placeholder="Paste a bearer token for authenticated endpoints"
+                  type="password"
+                />
+              </div>
+              <button
+                onClick={saveConnection}
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+              >
+                <Save size={15} />
+                Save Settings
+              </button>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+            <div className="mb-4 flex items-center gap-2">
+              <Server size={16} className="text-green-400" />
+              <h2 className="text-sm font-semibold text-gray-300">Runtime</h2>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <p className="text-xs text-gray-500">API health</p>
+                <p className={`mt-1 text-xl font-semibold ${healthQuery.data?.status === "ok" ? "text-green-300" : "text-red-300"}`}>
+                  {healthQuery.data?.status === "ok" ? "Operational" : "Unavailable"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Environment</p>
+                <p className="mt-1 text-xl font-semibold text-white">Web app</p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500">Authentication</p>
+                <p className="mt-1 text-sm text-gray-300">{token ? "Token stored locally" : "No token stored"}</p>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-3">
+          <section className="rounded-xl border border-gray-800 bg-gray-900 p-5 xl:col-span-2">
+            <div className="mb-4 flex items-center gap-2">
+              <Zap size={16} className="text-amber-400" />
+              <h2 className="text-sm font-semibold text-gray-300">LLM Providers</h2>
+            </div>
+            {providersLoading ? (
+              <div className="space-y-2">
+                {[0, 1, 2, 3].map((item) => <ProviderSkeleton key={item} />)}
+              </div>
+            ) : providersQuery.isError ? (
+              <div className="rounded-lg border border-red-900/60 bg-red-950/30 p-4 text-sm text-red-300">
+                Unable to load provider configuration.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {providers.map((provider: any) => (
+                  <div key={provider.name} className="flex items-center justify-between rounded-lg bg-gray-800 px-4 py-3">
+                    <div>
+                      <p className="text-sm font-medium capitalize text-white">{provider.name}</p>
+                      <p className="mt-0.5 text-xs text-gray-500">{provider.default_model}</p>
+                    </div>
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium ${
+                        provider.available ? "bg-green-950 text-green-300" : "bg-gray-700 text-gray-400"
+                      }`}
+                    >
+                      {provider.available && <CheckCircle2 size={12} />}
+                      {provider.available ? "Connected" : "No key"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+            <div className="mb-4 flex items-center gap-2">
+              <SettingsIcon size={16} className="text-indigo-400" />
+              <h2 className="text-sm font-semibold text-gray-300">Preferences</h2>
+            </div>
+            <div className="space-y-3">
+              <label className="flex items-center justify-between rounded-lg bg-gray-800 px-4 py-3">
+                <span className="text-sm text-gray-300">Dark theme</span>
+                <input type="checkbox" checked readOnly className="h-4 w-4 accent-indigo-600" />
+              </label>
+              <label className="flex items-center justify-between rounded-lg bg-gray-800 px-4 py-3">
+                <span className="text-sm text-gray-300">30s monitor refresh</span>
+                <input type="checkbox" checked readOnly className="h-4 w-4 accent-indigo-600" />
+              </label>
+              <div className="rounded-lg bg-gray-800 px-4 py-3">
+                <div className="flex items-center gap-2 text-sm text-gray-300">
+                  <KeyRound size={14} className="text-gray-500" />
+                  Secrets stay in backend environment variables.
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,8 +6,13 @@ export const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
-  const token = typeof window !== "undefined" ? localStorage.getItem("nexusai_token") : null;
-  if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (typeof window !== "undefined") {
+    const baseURL = localStorage.getItem("nexusai_api_url");
+    const token = localStorage.getItem("nexusai_token");
+
+    if (baseURL) config.baseURL = baseURL;
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+  }
   return config;
 });
 


### PR DESCRIPTION
Fixed the missing frontend routes for /monitor and /settings, which previously returned 404 from the sidebar navigation.

Changes Made

Added a new Monitor page showing:
API health status
Readiness status
Prometheus metrics summary
Service checks
Added a new Settings page showing:
Backend API URL configuration
Access token storage
Runtime status
LLM provider availability
Updated the frontend API client to use the saved backend URL from local storage.
Added the generated next-env.d.ts file required by Next.js TypeScript builds.
Issue Fixed

Closes #18